### PR TITLE
Extend tests for the "aws_cloudwatch_event_bus_policy" resource as suggested from the Terraform maintainers.

### DIFF
--- a/aws/resource_aws_cloudwatch_event_bus_policy_test.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy_test.go
@@ -1,17 +1,14 @@
 package aws
 
 import (
-	// "encoding/json"
 	"fmt"
 	"testing"
-	// "time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	// tfevents "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudwatchevents"
 )
 
 func TestAccAWSCloudwatchEventBusPolicy_basic(t *testing.T) {
@@ -33,6 +30,28 @@ func TestAccAWSCloudwatchEventBusPolicy_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudWatchEventBusPolicy_disappears(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_bus_policy.test"
+	rstring := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, events.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventBusDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudwatchEventBusPolicyConfig(rstring),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloudwatchEventBusPolicyExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchEventBusPolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -98,26 +117,4 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
   event_bus_name = aws_cloudwatch_event_bus.test.name
 }
 `, name)
-}
-
-func TestAccAWSCloudWatchEventBusPolicy_Disappears(t *testing.T) {
-	resourceName := "aws_cloudwatch_event_bus_policy.test"
-	busName := acctest.RandomWithPrefix("tf-acc-test-bus")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		ErrorCheck:   testAccErrorCheck(t, events.EndpointsID),
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudWatchEventBusDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudwatchEventBusPolicyConfig(busName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAWSCloudwatchEventBusPolicyExists(resourceName),
-					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchEventBusPolicy(), resourceName),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
 }

--- a/aws/resource_aws_cloudwatch_event_bus_policy_test.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy_test.go
@@ -25,37 +25,12 @@ func TestAccAWSCloudwatchEventBusPolicy_basic(t *testing.T) {
 			{
 				Config: testAccAWSCloudwatchEventBusPolicyConfig(rstring),
 				Check: resource.ComposeTestCheckFunc(
-					testAccAWSCloudWatchEventBusPolicyDocument(resourceName),
-					testAccCheckAWSCloudwatchEventBusPolicyExists(resourceName),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAWSCloudwatchEventBusPolicy_update(t *testing.T) {
-	resourceName := "aws_cloudwatch_event_bus_policy.test"
-	rstring := acctest.RandString(5)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAWSCloudWatchEventBusDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAWSCloudwatchEventBusPolicyConfig(rstring),
-				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCloudwatchEventBusPolicyExists(resourceName),
 					testAccAWSCloudWatchEventBusPolicyDocument(resourceName),
 				),
 			},
 			{
-				Config: testAccAWSCloudwatchEventBusPolicyConfigUpdated(rstring),
+				Config: testAccAWSCloudwatchEventBusPolicyConfigUpdate(rstring),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCloudwatchEventBusPolicyExists(resourceName),
 					testAccAWSCloudWatchEventBusPolicyDocument(resourceName),
@@ -195,7 +170,7 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
 `, name)
 }
 
-func testAccAWSCloudwatchEventBusPolicyConfigUpdated(name string) string {
+func testAccAWSCloudwatchEventBusPolicyConfigUpdate(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_bus" "test" {
   name = %[1]q

--- a/aws/resource_aws_cloudwatch_event_bus_policy_test.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy_test.go
@@ -109,8 +109,8 @@ func testAccAWSCloudWatchEventBusPolicyDocument(pr string) resource.TestCheckFun
 			return fmt.Errorf("No ID is set")
 		}
 
-		var policyFromState map[string]interface{}
-		err := json.Unmarshal([]byte(eventBusPolicyResource.Primary.Attributes["policy"]), &policyFromState)
+		var eventBusPolicyResourcePolicyDocument map[string]interface{}
+		err := json.Unmarshal([]byte(eventBusPolicyResource.Primary.Attributes["policy"]), &eventBusPolicyResourcePolicyDocument)
 
 		eventBusName := eventBusPolicyResource.Primary.ID
 
@@ -131,7 +131,7 @@ func testAccAWSCloudWatchEventBusPolicyDocument(pr string) resource.TestCheckFun
 			return fmt.Errorf("Not found: %s", pr)
 		}
 
-		if !reflect.DeepEqual(describedEventBusPolicy, policyFromState) {
+		if !reflect.DeepEqual(describedEventBusPolicy, eventBusPolicyResourcePolicyDocument) {
 			return fmt.Errorf("CloudWatch Events bus policy mismatch for '%s'", pr)
 		}
 

--- a/aws/resource_aws_cloudwatch_event_bus_policy_test.go
+++ b/aws/resource_aws_cloudwatch_event_bus_policy_test.go
@@ -1,14 +1,17 @@
 package aws
 
 import (
+	// "encoding/json"
 	"fmt"
 	"testing"
+	// "time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	events "github.com/aws/aws-sdk-go/service/cloudwatchevents"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	// tfevents "github.com/terraform-providers/terraform-provider-aws/aws/internal/service/cloudwatchevents"
 )
 
 func TestAccAWSCloudwatchEventBusPolicy_basic(t *testing.T) {
@@ -95,4 +98,26 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
   event_bus_name = aws_cloudwatch_event_bus.test.name
 }
 `, name)
+}
+
+func TestAccAWSCloudWatchEventBusPolicy_Disappears(t *testing.T) {
+	resourceName := "aws_cloudwatch_event_bus_policy.test"
+	busName := acctest.RandomWithPrefix("tf-acc-test-bus")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		ErrorCheck:   testAccErrorCheck(t, events.EndpointsID),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventBusDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudwatchEventBusPolicyConfig(busName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCloudwatchEventBusPolicyExists(resourceName),
+					testAccCheckResourceDisappears(testAccProvider, resourceAwsCloudWatchEventBusPolicy(), resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
 }

--- a/website/docs/r/cloudwatch_event_bus_policy.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus_policy.html.markdown
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "test" {
       "events:PutEvents",
     ]
     resources = [
-      "arn:aws:events:eu-west-1:111111111111:event-bus/default"
+      "arn:aws:events:eu-west-1:123456789012:event-bus/default"
     ]
 
     principals {
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_cloudwatch_event_bus_policy" "test" {
-  policy         = data.aws_iam_policy_document.access.json
+  policy         = data.aws_iam_policy_document.test.json
   event_bus_name = aws_cloudwatch_event_bus.test.name
 }
 ```
@@ -57,8 +57,8 @@ data "aws_iam_policy_document" "test" {
       "events:ListTagsForResource",
     ]
     resources = [
-      "arn:aws:events:eu-west-1:11111111111111:rule/*",
-      "arn:aws:events:eu-west-1:111111111111:event-bus/default"
+      "arn:aws:events:eu-west-1:123456789012:rule/*",
+      "arn:aws:events:eu-west-1:123456789012:event-bus/default"
     ]
 
     principals {
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_cloudwatch_event_bus_policy" "test" {
-  policy         = data.aws_iam_policy_document.access.json
+  policy         = data.aws_iam_policy_document.test.json
   event_bus_name = aws_cloudwatch_event_bus.test.name
 }
 ```
@@ -92,7 +92,7 @@ data "aws_iam_policy_document" "test" {
       "events:PutEvents",
     ]
     resources = [
-      "arn:aws:events:eu-west-1:111111111111:event-bus/default"
+      "arn:aws:events:eu-west-1:123456789012:event-bus/default"
     ]
 
     principals {
@@ -111,8 +111,8 @@ data "aws_iam_policy_document" "test" {
       "events:ListTagsForResource",
     ]
     resources = [
-      "arn:aws:events:eu-west-1:11111111111111:rule/*",
-      "arn:aws:events:eu-west-1:111111111111:event-bus/default"
+      "arn:aws:events:eu-west-1:123456789012:rule/*",
+      "arn:aws:events:eu-west-1:123456789012:event-bus/default"
     ]
 
     principals {
@@ -129,7 +129,7 @@ data "aws_iam_policy_document" "test" {
 }
 
 resource "aws_cloudwatch_event_bus_policy" "test" {
-  policy         = data.aws_iam_policy_document.access.json
+  policy         = data.aws_iam_policy_document.test.json
   event_bus_name = aws_cloudwatch_event_bus.test.name
 }
 ```

--- a/website/docs/r/cloudwatch_event_bus_policy.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus_policy.html.markdown
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
 
 ```hcl
 data "aws_iam_policy_document" "test" {
-  
+
   statement {
     sid    = "DevAccountAccess"
     effect = "Allow"
@@ -100,7 +100,7 @@ data "aws_iam_policy_document" "test" {
       identifiers = ["123456789012"]
     }
   }
-  
+
   statement {
     sid    = "OrganizationAccess"
     effect = "Allow"
@@ -140,6 +140,12 @@ The following arguments are supported:
 
 * `policy` - (Required) The text of the policy. For more information about building AWS IAM policy documents with Terraform, see the [AWS IAM Policy Document Guide](https://learn.hashicorp.com/terraform/aws/iam-policy).
 * `event_bus_name` - (Optional) The event bus to set the permissions on. If you omit this, the permissions are set on the `default` event bus.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the EventBrige event bus.
 
 ## Import
 

--- a/website/docs/r/cloudwatch_event_bus_policy.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus_policy.html.markdown
@@ -80,6 +80,60 @@ resource "aws_cloudwatch_event_bus_policy" "test" {
 }
 ```
 
+### Multiple Statements
+
+```hcl
+data "aws_iam_policy_document" "test" {
+  
+  statement {
+    sid    = "DevAccountAccess"
+    effect = "Allow"
+    actions = [
+      "events:PutEvents",
+    ]
+    resources = [
+      "arn:aws:events:eu-west-1:111111111111:event-bus/default"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["123456789012"]
+    }
+  }
+  
+  statement {
+    sid    = "OrganizationAccess"
+    effect = "Allow"
+    actions = [
+      "events:DescribeRule",
+      "events:ListRules",
+      "events:ListTargetsByRule",
+      "events:ListTagsForResource",
+    ]
+    resources = [
+      "arn:aws:events:eu-west-1:11111111111111:rule/*",
+      "arn:aws:events:eu-west-1:111111111111:event-bus/default"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = aws_organizations_organization.example.id
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_bus_policy" "test" {
+  policy         = data.aws_iam_policy_document.access.json
+  event_bus_name = aws_cloudwatch_event_bus.test.name
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/cloudwatch_event_bus_policy.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus_policy.html.markdown
@@ -145,7 +145,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The name of the EventBrige event bus.
+* `id` - The name of the EventBridge event bus.
 
 ## Import
 


### PR DESCRIPTION
Output from the "basic" test:
```bash
%  make testacc TESTARGS='-run=TestAccAWSCloudwatchEventBusPolicy_*'                                                                 
==> Checking that code complies with gofmt requirements...TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudwatchEventBusPolicy_* -timeout 180m=== RUN   TestAccAWSCloudwatchEventBusPolicy_basic=== PAUSE TestAccAWSCloudwatchEventBusPolicy_basic=== CONT  TestAccAWSCloudwatchEventBusPolicy_basic--- PASS: TestAccAWSCloudwatchEventBusPolicy_basic (83.88s)PASSok      github.com/terraform-providers/terraform-provider-aws/aws       85.905s
```

Output from the "disappears" test:
```
%  make testacc TESTARGS='-run=TestAccAWSCloudWatchEventBusPolicy_disappears'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSCloudWatchEventBusPolicy_disappears -timeout 180m
=== RUN   TestAccAWSCloudWatchEventBusPolicy_disappears
=== PAUSE TestAccAWSCloudWatchEventBusPolicy_disappears
=== CONT  TestAccAWSCloudWatchEventBusPolicy_disappears
--- PASS: TestAccAWSCloudWatchEventBusPolicy_disappears (161.47s)
PASS
ok      github.com/terraform-providers/terraform-provider-aws/aws       163.496s
```